### PR TITLE
Added flake8 config to increase line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 90


### PR DESCRIPTION
Added this so that when we use black for formatting then it will not cause flake8 to complain as it uses a default line length of 88.